### PR TITLE
Versioned configuration

### DIFF
--- a/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
+++ b/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
@@ -50,8 +50,8 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ConfigurationMigrator.cs" />
     <Compile Include="Detour\CustomPlayClickSound.cs" />
+    <Compile Include="Migration\ConfigurationMigrator.cs" />
     <Compile Include="Migration\ConfigurationV0.cs" />
     <Compile Include="SoundPatchers\MiscPatcher.cs" />
     <Compile Include="SoundPatchers\SoundContainer.cs" />

--- a/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
+++ b/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
@@ -50,7 +50,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ConfigurationMigrator.cs" />
     <Compile Include="Detour\CustomPlayClickSound.cs" />
+    <Compile Include="Migration\ConfigurationV0.cs" />
     <Compile Include="SoundPatchers\MiscPatcher.cs" />
     <Compile Include="SoundPatchers\SoundContainer.cs" />
     <Compile Include="SoundPatchers\VehiclesPatcher.cs" />

--- a/CSL Ambient Sounds Tuner/Configuration.cs
+++ b/CSL Ambient Sounds Tuner/Configuration.cs
@@ -6,12 +6,13 @@ using System.Text;
 using System.Xml.Serialization;
 using AmbientSoundsTuner.Utils;
 using CommonShared;
+using CommonShared.Configuration;
 using CommonShared.Utils;
 
 namespace AmbientSoundsTuner
 {
     [XmlRoot("Configuration")]
-    public class Configuration : Config
+    public class Configuration : VersionedConfig
     {
         [XmlRoot("State")]
         public class StateConfig
@@ -21,6 +22,8 @@ namespace AmbientSoundsTuner
 
         public Configuration()
         {
+            this.Version = 1;
+
             this.State = new StateConfig();
             this.ExtraDebugLogging = false;
 

--- a/CSL Ambient Sounds Tuner/ConfigurationMigrator.cs
+++ b/CSL Ambient Sounds Tuner/ConfigurationMigrator.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+using AmbientSoundsTuner.Migration;
+using CommonShared.Configuration;
+
+namespace AmbientSoundsTuner
+{
+    public class ConfigurationMigrator : ConfigMigratorBase<Configuration>
+    {
+        public ConfigurationMigrator()
+        {
+            this.MigrationMethods = new Dictionary<uint, Func<object, object>>()
+            {
+                { 0, this.MigrateFromVersion0 }
+            };
+
+            this.VersionTypes = new Dictionary<uint, Type>()
+            {
+                { 0, typeof(ConfigurationV0) }
+            };
+        }
+
+        protected object MigrateFromVersion0(object oldConfig)
+        {
+            ConfigurationV0 config = (ConfigurationV0)oldConfig;
+            Configuration newConfig = new Configuration();
+
+            foreach (var kvp in config.State.AmbientVolumes)
+            {
+                newConfig.AmbientVolumes.Add(kvp.Key, kvp.Value);
+            }
+            foreach (var kvp in config.State.EffectVolumes)
+            {
+                newConfig.VehicleVolumes.Add(kvp.Key, kvp.Value);
+            }
+
+            return newConfig;
+        }
+    }
+}

--- a/CSL Ambient Sounds Tuner/Migration/ConfigurationMigrator.cs
+++ b/CSL Ambient Sounds Tuner/Migration/ConfigurationMigrator.cs
@@ -7,7 +7,7 @@ using System.Xml.Serialization;
 using AmbientSoundsTuner.Migration;
 using CommonShared.Configuration;
 
-namespace AmbientSoundsTuner
+namespace AmbientSoundsTuner.Migration
 {
     public class ConfigurationMigrator : ConfigMigratorBase<Configuration>
     {
@@ -29,6 +29,7 @@ namespace AmbientSoundsTuner
             ConfigurationV0 config = (ConfigurationV0)oldConfig;
             Configuration newConfig = new Configuration();
 
+            newConfig.ExtraDebugLogging = config.ExtraDebugLogging;
             foreach (var kvp in config.State.AmbientVolumes)
             {
                 newConfig.AmbientVolumes.Add(kvp.Key, kvp.Value);

--- a/CSL Ambient Sounds Tuner/Migration/ConfigurationV0.cs
+++ b/CSL Ambient Sounds Tuner/Migration/ConfigurationV0.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+using AmbientSoundsTuner.Utils;
+using CommonShared;
+using CommonShared.Configuration;
+using CommonShared.Utils;
+
+namespace AmbientSoundsTuner.Migration
+{
+    [XmlRoot("Configuration")]
+    public class ConfigurationV0 : Config
+    {
+        [XmlRoot("State")]
+        public class StateConfig
+        {
+            public StateConfig()
+            {
+                this.AmbientVolumes = new SerializableDictionary<AudioManager.AmbientType, float>();
+                this.EffectVolumes = new SerializableDictionary<string, float>();
+            }
+
+            [XmlElement("AmbientVolumes")]
+            public SerializableDictionary<AudioManager.AmbientType, float> AmbientVolumes { get; set; }
+
+            [XmlElement("EffectVolumes")]
+            public SerializableDictionary<string, float> EffectVolumes { get; set; }
+        }
+
+        public ConfigurationV0()
+        {
+            this.State = new StateConfig();
+            this.ExtraDebugLogging = false;
+        }
+
+        public StateConfig State { get; set; }
+
+        public bool ExtraDebugLogging { get; set; }
+    }
+}

--- a/CSL Ambient Sounds Tuner/Mod.cs
+++ b/CSL Ambient Sounds Tuner/Mod.cs
@@ -10,6 +10,7 @@ using AmbientSoundsTuner.UI;
 using AmbientSoundsTuner.Utils;
 using ColossalFramework.Plugins;
 using CommonShared;
+using CommonShared.Configuration;
 using CommonShared.Utils;
 using ICities;
 using UnityEngine;
@@ -93,7 +94,7 @@ namespace AmbientSoundsTuner
         {
             this.CheckIncompatibility();
 
-            Mod.Settings = Config.LoadConfig<Configuration>(Mod.SettingsFilename);
+            Mod.Settings = VersionedConfig.LoadConfig<Configuration>(Mod.SettingsFilename, new ConfigurationMigrator());
             Mod.Log.EnableDebugLogging = Mod.Settings.ExtraDebugLogging;
 
             if (Mod.Settings.ExtraDebugLogging)

--- a/CSL Ambient Sounds Tuner/Mod.cs
+++ b/CSL Ambient Sounds Tuner/Mod.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Text;
 using AmbientSoundsTuner.Compatibility;
 using AmbientSoundsTuner.Detour;
+using AmbientSoundsTuner.Migration;
 using AmbientSoundsTuner.SoundPatchers;
 using AmbientSoundsTuner.UI;
 using AmbientSoundsTuner.Utils;

--- a/CSL Common Shared/CSL Common Shared.csproj
+++ b/CSL Common Shared/CSL Common Shared.csproj
@@ -52,7 +52,10 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Config.cs" />
+    <Compile Include="Configuration\Config.cs" />
+    <Compile Include="Configuration\ConfigMigratorBase.cs" />
+    <Compile Include="Configuration\IConfigMigrator.cs" />
+    <Compile Include="Configuration\VersionedConfig.cs" />
     <Compile Include="SerializableDictionary.cs" />
     <Compile Include="Utils\DetourUtils.cs" />
     <Compile Include="Events\AssetEditorEvents.cs" />

--- a/CSL Common Shared/Configuration/Config.cs
+++ b/CSL Common Shared/Configuration/Config.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Xml.Serialization;
 
-namespace CommonShared
+namespace CommonShared.Configuration
 {
     /// <summary>
     /// An abstract class that provides basic implementation for loading and saving configuration files.

--- a/CSL Common Shared/Configuration/ConfigMigratorBase.cs
+++ b/CSL Common Shared/Configuration/ConfigMigratorBase.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace CommonShared.Configuration
+{
+    /// <summary>
+    /// An abstract class that implements basic functionality of <see cref="IConfigMigrator"/>.
+    /// </summary>
+    /// <typeparam name="T">The configuration object type.</typeparam>
+    public abstract class ConfigMigratorBase<T> : IConfigMigrator<T> where T : VersionedConfig, new()
+    {
+        /// <summary>
+        /// Gets or sets the migration methods that are used for different versions.
+        /// </summary>
+        protected virtual IDictionary<uint, Func<object, object>> MigrationMethods { get; set; }
+
+        /// <summary>
+        /// Gets or sets the configuration object types used for different versions.
+        /// </summary>
+        protected virtual IDictionary<uint, Type> VersionTypes { get; set; }
+
+        /// <summary>
+        /// Migrate a configuration file.
+        /// </summary>
+        /// <param name="version">The current version of the configuration file.</param>
+        /// <param name="stream">The stream of the configuration file.</param>
+        /// <returns>An up-to-date configuration object.</returns>
+        public T Migrate(uint version, Stream stream)
+        {
+            T currentConfig = new T();
+            if (version == currentConfig.Version)
+            {
+                // Using latest version
+                return (T)new XmlSerializer(typeof(T)).Deserialize(stream);
+            }
+            else
+            {
+                // Using an outdated version
+                object config = new XmlSerializer(this.VersionTypes[version]).Deserialize(stream);
+                while (version < currentConfig.Version)
+                {
+                    config = this.MigrationMethods[version](config);
+                    version++;
+                }
+                return (T)config;
+            }
+        }
+    }
+}

--- a/CSL Common Shared/Configuration/IConfigMigrator.cs
+++ b/CSL Common Shared/Configuration/IConfigMigrator.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace CommonShared.Configuration
+{
+    /// <summary>
+    /// An interface for implementing configuration migrators.
+    /// Typically you would want to use <see cref="ConfigMigratorBase"/>.
+    /// </summary>
+    /// <typeparam name="T">The configuration object type.</typeparam>
+    public interface IConfigMigrator<T> where T : VersionedConfig
+    {
+        /// <summary>
+        /// Migrate a configuration file.
+        /// </summary>
+        /// <param name="version">The current version of the configuration file.</param>
+        /// <param name="stream">The stream of the configuration file.</param>
+        /// <returns>An up-to-date configuration object.</returns>
+        T Migrate(uint version, Stream stream);
+    }
+}

--- a/CSL Common Shared/Configuration/VersionedConfig.cs
+++ b/CSL Common Shared/Configuration/VersionedConfig.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Serialization;
+
+namespace CommonShared.Configuration
+{
+    /// <summary>
+    /// A class that provides basic implementation for loading and saving versioned configuration files.
+    /// </summary>
+    [XmlRoot("Configuration")]
+    public class VersionedConfig : Config
+    {
+        /// <summary>
+        /// Gets or sets the version of this configuration file.
+        /// </summary>
+        [XmlAttribute("version")]
+        public virtual uint Version { get; set; }
+
+        /// <summary>
+        /// Loads the configuration from a file.
+        /// </summary>
+        /// <typeparam name="T">The config object type.</typeparam>
+        /// <param name="filename">The name of the configuration file.</param>
+        /// <param name="migrator">The config migrator object.</param>
+        public static T LoadConfig<T>(string filename, IConfigMigrator<T> migrator) where T : VersionedConfig, new()
+        {
+            if (File.Exists(filename))
+            {
+                using (FileStream fs = new FileStream(filename, FileMode.Open, FileAccess.Read))
+                {
+                    VersionedConfig versionedConfig = (VersionedConfig)new XmlSerializer(typeof(VersionedConfig)).Deserialize(fs);
+                    fs.Position = 0;
+                    return migrator.Migrate(versionedConfig.Version, fs);
+                }
+            }
+            return new T();
+        }
+    }
+}

--- a/CSL Common Shared/UI/Window.cs
+++ b/CSL Common Shared/UI/Window.cs
@@ -83,7 +83,7 @@ namespace CommonShared.UI
             UILabel title = this.TitleObject.AddComponent<UILabel>();
             title.text = this.title;
             title.textAlignment = UIHorizontalAlignment.Center;
-            title.position = new Vector3(this.width / 2 - title.width / 2, -TitleBarHeight / 2 + title.height / 2);
+            title.position = new Vector3(this.width / 2 - title.width / 2, -TitleBarHeight / 2 + title.height / 2).RoundToInt();
             title.anchor = UIAnchorStyle.Top | UIAnchorStyle.Left | UIAnchorStyle.Right;
             title.atlas = this.atlas;
         }

--- a/appveyor/Build.ps1
+++ b/appveyor/Build.ps1
@@ -1,6 +1,8 @@
 # Restore our NuGet packages
 nuget sources Add -Name CitiesSkylines -Source $env:NUGET_CSL_URL -UserName $env:NUGET_CSL_USERNAME -Password $env:NUGET_CSL_PASSWORD -Verbosity quiet -NonInteractive
+if ($LASTEXITCODE -gt 0) { exit $LASTEXITCODE }
 nuget restore .\appveyor\packages.config -SolutionDirectory .\ -NonInteractive
+if ($LASTEXITCODE -gt 0) { exit $LASTEXITCODE }
 
 [xml]$packages = Get-Content .\appveyor\packages.config
 $referencePath = ($packages.packages.package | % {(Get-Location).ToString() + "\packages\$($_.id).$($_.version)\lib\$($_.targetFramework)\"}) -Join ";"
@@ -8,6 +10,7 @@ $referencePath = ($packages.packages.package | % {(Get-Location).ToString() + "\
 
 # Do the actual build
 msbuild /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal /p:ReferencePath="$referencePath"
+if ($LASTEXITCODE -gt 0) { exit $LASTEXITCODE }
 
 
 # Copy the files we need to .\bin


### PR DESCRIPTION
Because of the amount of different volume settings that are included with the latest additions, having a versioned configuration file is a must. If there are any changes in the structure of the configuration file, we can now write code that will migrate older configuration file versions to the most recent one.

In other words, the configuration settings should not be reset anymore when there's a change in the file structure. Unless it's completely incompatible of course.
