### PR TITLE
Support Cities Skylines v1.1.1

### DIFF
--- a/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
+++ b/CSL Ambient Sounds Tuner/CSL Ambient Sounds Tuner.csproj
@@ -51,6 +51,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Detour\CustomPlayClickSound.cs" />
+    <Compile Include="Migration\ConfigurationV1.cs" />
     <Compile Include="Migration\ConfigurationMigrator.cs" />
     <Compile Include="Migration\ConfigurationV0.cs" />
     <Compile Include="SoundPatchers\MiscPatcher.cs" />

--- a/CSL Ambient Sounds Tuner/Defs/GameObjectDefs.cs
+++ b/CSL Ambient Sounds Tuner/Defs/GameObjectDefs.cs
@@ -9,7 +9,7 @@ namespace AmbientSoundsTuner.Defs
     {
         public const string ID_EFFECTS = "Effects";
         public const string ID_LIBRARY_OPTIONSPANEL = "(Library) OptionsPanel";
-        public const string ID_OPTIONSCONTAINER = "OptionsContainer";
-        public const string ID_OPTIONTABSTRIP = "OptionTabStrip";
+        public const string ID_KEYMAPPING_TABSTRIP = "KeyMappingTabStrip";
+        public const string ID_OPTIONS_CONTAINER = "OptionsContainer";
     }
 }

--- a/CSL Ambient Sounds Tuner/Migration/ConfigurationMigrator.cs
+++ b/CSL Ambient Sounds Tuner/Migration/ConfigurationMigrator.cs
@@ -15,29 +15,60 @@ namespace AmbientSoundsTuner.Migration
         {
             this.MigrationMethods = new Dictionary<uint, Func<object, object>>()
             {
-                { 0, this.MigrateFromVersion0 }
+                { 0, this.MigrateFromVersion0 },
+                { 1, this.MigrateFromVersion1 }
             };
 
             this.VersionTypes = new Dictionary<uint, Type>()
             {
-                { 0, typeof(ConfigurationV0) }
+                { 0, typeof(ConfigurationV0) },
+                { 1, typeof(ConfigurationV1) }
             };
         }
 
         protected object MigrateFromVersion0(object oldConfig)
         {
             ConfigurationV0 config = (ConfigurationV0)oldConfig;
-            Configuration newConfig = new Configuration();
+            ConfigurationV1 newConfig = new ConfigurationV1();
 
             newConfig.ExtraDebugLogging = config.ExtraDebugLogging;
             foreach (var kvp in config.State.AmbientVolumes)
-            {
                 newConfig.AmbientVolumes.Add(kvp.Key, kvp.Value);
-            }
             foreach (var kvp in config.State.EffectVolumes)
-            {
                 newConfig.VehicleVolumes.Add(kvp.Key, kvp.Value);
+
+            return newConfig;
+        }
+
+        protected object MigrateFromVersion1(object oldConfig)
+        {
+            ConfigurationV1 config = (ConfigurationV1)oldConfig;
+            Configuration newConfig = new Configuration();
+
+            newConfig.ExtraDebugLogging = config.ExtraDebugLogging;
+            foreach (var kvp in config.AmbientVolumes)
+                newConfig.AmbientVolumes.Add(kvp.Key, kvp.Value);
+            foreach (var kvp in config.AnimalVolumes)
+                newConfig.AnimalVolumes.Add(kvp.Key, kvp.Value);
+            foreach (var kvp in config.BuildingVolumes)
+                newConfig.BuildingVolumes.Add(kvp.Key, kvp.Value);
+            foreach (var kvp in config.VehicleVolumes)
+            {
+                switch (kvp.Key)
+                {
+                    case "Small Car Movement":
+                        newConfig.VehicleVolumes.Add("Small Car Sound", kvp.Value);
+                        break;
+                    case "Large Car Movement":
+                        newConfig.VehicleVolumes.Add("Large Car Sound", kvp.Value);
+                        break;
+                    default:
+                        newConfig.VehicleVolumes.Add(kvp.Key, kvp.Value);
+                        break;
+                }
             }
+            foreach (var kvp in config.MiscVolumes)
+                newConfig.MiscVolumes.Add(kvp.Key, kvp.Value);
 
             return newConfig;
         }

--- a/CSL Ambient Sounds Tuner/Migration/ConfigurationV1.cs
+++ b/CSL Ambient Sounds Tuner/Migration/ConfigurationV1.cs
@@ -9,10 +9,10 @@ using CommonShared;
 using CommonShared.Configuration;
 using CommonShared.Utils;
 
-namespace AmbientSoundsTuner
+namespace AmbientSoundsTuner.Migration
 {
     [XmlRoot("Configuration")]
-    public class Configuration : VersionedConfig
+    public class ConfigurationV1 : VersionedConfig
     {
         [XmlRoot("State")]
         public class StateConfig
@@ -20,9 +20,9 @@ namespace AmbientSoundsTuner
             public StateConfig() { }
         }
 
-        public Configuration()
+        public ConfigurationV1()
         {
-            this.Version = 2;
+            this.Version = 1;
 
             this.State = new StateConfig();
             this.ExtraDebugLogging = false;

--- a/CSL Ambient Sounds Tuner/SoundPatchers/SoundsCollection.cs
+++ b/CSL Ambient Sounds Tuner/SoundPatchers/SoundsCollection.cs
@@ -326,10 +326,12 @@ namespace AmbientSoundsTuner.SoundPatchers
             public const string ID_AIRCRAFT_MOVEMENT = "Aircraft Movement";
             public const string ID_AMBULANCE_SIREN = "Ambulance Siren";
             public const string ID_FIRE_TRUCK_SIREN = "Fire Truck Siren";
-            public const string ID_LARGE_CAR_MOVEMENT = "Large Car Movement";
+            private const string ID_LARGE_CAR_MOVEMENT = "Large Car Movement";
+            public const string ID_LARGE_CAR_SOUND = "Large Car Sound";
             public const string ID_METRO_MOVEMENT = "Metro Movement";
             public const string ID_POLICE_CAR_SIREN = "Police Car Siren";
-            public const string ID_SMALL_CAR_MOVEMENT = "Small Car Movement";
+            private const string ID_SMALL_CAR_MOVEMENT = "Small Car Movement";
+            public const string ID_SMALL_CAR_SOUND = "Small Car Sound";
             public const string ID_TRAIN_MOVEMENT = "Train Movement";
             public const string ID_TRANSPORT_ARRIVE = "Transport Arrive";
 
@@ -342,25 +344,39 @@ namespace AmbientSoundsTuner.SoundPatchers
             {
                 get
                 {
+                    SoundEffect soundEffect = null;
+                    MultiEffect multiEffect = null;
+
                     switch (id)
                     {
                         case ID_AIRCRAFT_MOVEMENT:
                         case ID_AMBULANCE_SIREN:
                         case ID_FIRE_TRUCK_SIREN:
-                        case ID_LARGE_CAR_MOVEMENT:
                         case ID_METRO_MOVEMENT:
                         case ID_POLICE_CAR_SIREN:
-                        case ID_SMALL_CAR_MOVEMENT:
                         case ID_TRAIN_MOVEMENT:
                         case ID_TRANSPORT_ARRIVE:
-                            EffectInfo effectInfo = EffectCollection.FindEffect(id);
-                            SoundEffect soundEffect = effectInfo as SoundEffect;
+                            soundEffect = EffectCollection.FindEffect(id) as SoundEffect;
                             if (soundEffect != null)
                             {
                                 return new SoundContainer(soundEffect);
                             }
                             break;
+
+                        case ID_SMALL_CAR_SOUND:
+                            multiEffect = EffectCollection.FindEffect(ID_SMALL_CAR_MOVEMENT) as MultiEffect;
+                            break;
+
+                        case ID_LARGE_CAR_SOUND:
+                            multiEffect = EffectCollection.FindEffect(ID_LARGE_CAR_MOVEMENT) as MultiEffect;
+                            break;
                     }
+
+                    if (multiEffect != null)
+                    {
+                        return new SoundContainer(multiEffect.m_effects.FirstOrDefault(e => e.m_effect != null && e.m_effect.name == id).m_effect as SoundEffect);
+                    }
+
                     return new SoundContainer();
                 }
             }

--- a/CSL Ambient Sounds Tuner/SoundPatchers/VehiclesPatcher.cs
+++ b/CSL Ambient Sounds Tuner/SoundPatchers/VehiclesPatcher.cs
@@ -16,10 +16,10 @@ namespace AmbientSoundsTuner.SoundPatchers
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_AIRCRAFT_MOVEMENT, 0.5f);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_AMBULANCE_SIREN, 1);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_FIRE_TRUCK_SIREN, 3);
-            this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_LARGE_CAR_MOVEMENT, 1.5f);
+            this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, 1.5f);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_METRO_MOVEMENT, 0.5f);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_POLICE_CAR_SIREN, 1);
-            this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_SMALL_CAR_MOVEMENT, 1.5f);
+            this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, 1.5f);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_TRAIN_MOVEMENT, 0.5f);
             this.DefaultVolumes.Add(SoundsCollection.VehicleSounds.ID_TRANSPORT_ARRIVE, 1);
         }

--- a/CSL Ambient Sounds Tuner/UI/AdvancedOptions.cs
+++ b/CSL Ambient Sounds Tuner/UI/AdvancedOptions.cs
@@ -38,6 +38,9 @@ namespace AmbientSoundsTuner.UI
             advancedOptionsButton.autoSize = true;
             advancedOptionsButton.textPadding = new RectOffset(8, 8, 8, 8);
             advancedOptionsButton.textScale = 1.3f;
+            UIPanel lastPanel = audioOptionsPanel.GetComponentsInChildren<UIPanel>().OrderByDescending(p => p.relativePosition.y).First();
+            advancedOptionsButton.relativePosition = new Vector3(lastPanel.relativePosition.x + 14, lastPanel.relativePosition.y + lastPanel.size.y + 14);
+
             advancedOptionsButton.eventClick += advancedOptionsButton_eventClick;
 
             advancedOptions = new GameObject("AdvancedSoundsTuner");
@@ -65,7 +68,7 @@ namespace AmbientSoundsTuner.UI
             Mod.Log.Debug("Opening Sounds Tuner window");
 
             UIView.GetAView().AttachUIComponent(advancedOptions);
-            advancedOptionsWindow.transform.SetParent(GameObject.Find(GameObjectDefs.ID_LIBRARY_OPTIONSPANEL).GetComponent<OptionsPanel>().component.transform);
+            advancedOptionsWindow.transform.SetParent(GameObject.Find(GameObjectDefs.ID_LIBRARY_OPTIONSPANEL).GetComponent<UIPanel>().transform);
             advancedOptionsWindow.Show(true);
 
             Window.ShowWindow(advancedOptions.GetComponent<AdvancedOptionsWindow>());

--- a/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
+++ b/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
@@ -54,7 +54,7 @@ namespace AmbientSoundsTuner.UI
             { SoundsCollection.BuildingSounds.ID_ON_UPGRADE, "On Upgrade" },
 
             { SoundsCollection.VehicleSounds.ID_AIRCRAFT_MOVEMENT, "Aircrafts" },
-            { SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, "Cars (Small)" },
+            { SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, "Cars (Small)/Scooters" },
             { SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, "Cars (Large)" },
             { SoundsCollection.VehicleSounds.ID_AMBULANCE_SIREN, "Sirens (Ambulances)" },
             { SoundsCollection.VehicleSounds.ID_FIRE_TRUCK_SIREN, "Sirens (Fire Trucks)" },
@@ -140,10 +140,10 @@ namespace AmbientSoundsTuner.UI
         public float vehicleVolumeAircraftMovement;
         public float vehicleVolumeAmbulanceSiren;
         public float vehicleVolumeFireTruckSiren;
-        public float vehicleVolumeLargeCarMovement;
+        public float vehicleVolumeLargeCarSound;
         public float vehicleVolumeMetroMovement;
         public float vehicleVolumePoliceCarSiren;
-        public float vehicleVolumeSmallCarMovement;
+        public float vehicleVolumeSmallCarSound;
         public float vehicleVolumeTrainMovement;
         public float vehicleVolumeTransportArrive;
         public float miscVolumeBuildingBulldoze;
@@ -285,10 +285,10 @@ namespace AmbientSoundsTuner.UI
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_AIRCRAFT_MOVEMENT, new { vehicleVolumeAircraftMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_AMBULANCE_SIREN, new { vehicleVolumeAmbulanceSiren });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_FIRE_TRUCK_SIREN, new { vehicleVolumeFireTruckSiren }, 0, 3);
-            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, new { vehicleVolumeLargeCarMovement }, 0, 1.5f);
+            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, new { vehicleVolumeLargeCarSound }, 0, 1.5f);
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_METRO_MOVEMENT, new { vehicleVolumeMetroMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_POLICE_CAR_SIREN, new { vehicleVolumePoliceCarSiren });
-            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, new { vehicleVolumeSmallCarMovement }, 0, 1.5f);
+            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, new { vehicleVolumeSmallCarSound }, 0, 1.5f);
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_TRAIN_MOVEMENT, new { vehicleVolumeTrainMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_TRANSPORT_ARRIVE, new { vehicleVolumeTransportArrive });
 

--- a/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
+++ b/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
@@ -54,8 +54,8 @@ namespace AmbientSoundsTuner.UI
             { SoundsCollection.BuildingSounds.ID_ON_UPGRADE, "On Upgrade" },
 
             { SoundsCollection.VehicleSounds.ID_AIRCRAFT_MOVEMENT, "Aircrafts" },
-            { SoundsCollection.VehicleSounds.ID_SMALL_CAR_MOVEMENT, "Cars (Small)" },
-            { SoundsCollection.VehicleSounds.ID_LARGE_CAR_MOVEMENT, "Cars (Large)" },
+            { SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, "Cars (Small)" },
+            { SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, "Cars (Large)" },
             { SoundsCollection.VehicleSounds.ID_AMBULANCE_SIREN, "Sirens (Ambulances)" },
             { SoundsCollection.VehicleSounds.ID_FIRE_TRUCK_SIREN, "Sirens (Fire Trucks)" },
             { SoundsCollection.VehicleSounds.ID_POLICE_CAR_SIREN, "Sirens (Police Cars)" },
@@ -285,10 +285,10 @@ namespace AmbientSoundsTuner.UI
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_AIRCRAFT_MOVEMENT, new { vehicleVolumeAircraftMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_AMBULANCE_SIREN, new { vehicleVolumeAmbulanceSiren });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_FIRE_TRUCK_SIREN, new { vehicleVolumeFireTruckSiren }, 0, 3);
-            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_LARGE_CAR_MOVEMENT, new { vehicleVolumeLargeCarMovement }, 0, 1.5f);
+            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_LARGE_CAR_SOUND, new { vehicleVolumeLargeCarMovement }, 0, 1.5f);
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_METRO_MOVEMENT, new { vehicleVolumeMetroMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_POLICE_CAR_SIREN, new { vehicleVolumePoliceCarSiren });
-            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_SMALL_CAR_MOVEMENT, new { vehicleVolumeSmallCarMovement }, 0, 1.5f);
+            this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_SMALL_CAR_SOUND, new { vehicleVolumeSmallCarMovement }, 0, 1.5f);
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_TRAIN_MOVEMENT, new { vehicleVolumeTrainMovement });
             this.AddVehicleSlider(SoundsCollection.VehicleSounds.ID_TRANSPORT_ARRIVE, new { vehicleVolumeTransportArrive });
 

--- a/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
+++ b/CSL Ambient Sounds Tuner/UI/AdvancedOptionsWindow.cs
@@ -176,8 +176,8 @@ namespace AmbientSoundsTuner.UI
             this.Tabstrip.tabPages = this.TabContainer;
 
             // Get template button from the options panel tabstrip
-            UITabstrip optionTabStrip = GameObject.Find(GameObjectDefs.ID_OPTIONTABSTRIP).GetComponent<UITabstrip>();
-            UIButton tabStripButtonTemplate = optionTabStrip.GetComponentInChildren<UIButton>();
+            UITabstrip keyMappingTabStrip = GameObject.Find(GameObjectDefs.ID_KEYMAPPING_TABSTRIP).GetComponent<UITabstrip>();
+            UIButton tabStripButtonTemplate = keyMappingTabStrip.GetComponentInChildren<UIButton>();
 
             this.AmbientsTabButton = this.Tabstrip.AddTab("AMBIENTS", tabStripButtonTemplate, true);
             this.AmbientsTabButton.playAudioEvents = true;

--- a/CSL Ambient Sounds Tuner/Utils/OptionsPanelUtils.cs
+++ b/CSL Ambient Sounds Tuner/Utils/OptionsPanelUtils.cs
@@ -12,10 +12,10 @@ namespace AmbientSoundsTuner.Utils
     {
         public static UIPanel GetAudioOptionsPanel()
         {
-            GameObject optionsContainer = GameObject.Find(GameObjectDefs.ID_OPTIONSCONTAINER);
+            GameObject optionsContainer = GameObject.Find(GameObjectDefs.ID_OPTIONS_CONTAINER);
             if (optionsContainer != null)
             {
-                return optionsContainer.GetComponentsInChildren<UIPanel>().FirstOrDefault(p => p.name == "Audio");
+                return optionsContainer.GetComponentsInChildren<UIPanel>().FirstOrDefault(p => p.name == "AudioSettings");
             }
             return null;
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # We follow the versioning of Cities Skylines
-version: 1.1.0.{build}
+version: 1.1.1.{build}
 
 configuration: Release
 

--- a/appveyor/packages.config
+++ b/appveyor/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CitiesSkylinesAPI" version="1.1.0" targetFramework="net35" />
+  <package id="CitiesSkylinesAPI" version="1.1.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Hotfixes to support Cities Skylines version 1.1.1. This contains no feature additions.
